### PR TITLE
opencap alias support

### DIFF
--- a/GUI/Front/html.go
+++ b/GUI/Front/html.go
@@ -236,7 +236,7 @@ var HTMLNanollet = HTMLPAGE(`<main application="nanollet">
     <section page="send">
         <div class="middle">
 
-            <label for="address">ADDRESS</label>
+            <label for="address">ADDRESS OR OPENCAP ALIAS</label>
             <textarea spellcheck="false" class="address" rows="2"></textarea>
 
             <label for="address">AMOUNT</label>
@@ -290,5 +290,4 @@ var HTMLNanollet = HTMLPAGE(`<main application="nanollet">
     </section>
 
 
-</main>
-`)
+</main>`)

--- a/GUI/Front/html/nanollet.html
+++ b/GUI/Front/html/nanollet.html
@@ -3,7 +3,7 @@
     <section page="send">
         <div class="middle">
 
-            <label for="address">ADDRESS</label>
+            <label for="address">ADDRESS OR OPENCAP ALIAS</label>
             <textarea spellcheck="false" class="address" rows="2"></textarea>
 
             <label for="address">AMOUNT</label>

--- a/Util/alias.go
+++ b/Util/alias.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	opencap "github.com/lane-c-wagner/go-opencap"
+	opencap "github.com/opencap/go-opencap"
 )
 
 // LookupResponse represents the return value of an OpenCAP GET addresses

--- a/Util/alias.go
+++ b/Util/alias.go
@@ -1,0 +1,44 @@
+package Util
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+
+	opencap "github.com/lane-c-wagner/go-opencap"
+)
+
+// LookupResponse represents the return value of an OpenCAP GET addresses
+// request
+type LookupResponse struct {
+	AddressType int    `json:"address_type`
+	Address     string `json:address`
+}
+
+// LookupAlias gets the address at the given alias
+func LookupAlias(alias string) (string, error) {
+	_, domain, err := opencap.ValidateAlias(alias)
+	if err != nil {
+		return "", errors.New("Invalid alias provided")
+	}
+
+	host, err := opencap.GetHost(domain)
+	if err != nil {
+		return "", errors.New("No host found for the given alias")
+	}
+
+	respRaw, err := http.Get("https://" + host + "/v1/addresses?alias=" + alias + "&address_type=300")
+	if err != nil {
+		return "", errors.New("No host found for the given alias")
+	}
+
+	defer respRaw.Body.Close()
+	body, err := ioutil.ReadAll(respRaw.Body)
+	resp := LookupResponse{}
+	err = json.Unmarshal(body, &resp)
+	if err != nil {
+		return "", errors.New("Bad data returned from alias host")
+	}
+	return resp.Address, nil
+}


### PR DESCRIPTION
I added support for OpenCAP aliases. I tested to make sure the addresses are pulled in correctly. Obviously I raised an issue where my wallet isn't creating a receive block but that shouldn't change this PR.

I'm not sure if I messed up how you wanted to organize your code or not, let me know.

I think those generated files should NOT be in the repo. I was talking about the files below that should be in the repo:

* libsciter-gtk-64.so
* sciter.dll
* sciter-osx-64.dylib


In order to test, make an alias at https://ogdolo.com