### PR TITLE
Accept ConfirmACK from "unknown" peers

### DIFF
--- a/GUI/App/Background/tracker.go
+++ b/GUI/App/Background/tracker.go
@@ -76,10 +76,11 @@ func StartAddress(w *DOM.Window) error {
 
 	}
 
+	go realtimeUpdate(w)
+
 	Storage.TransactionStorage.Add(txs...)
 	DOM.UpdateAmount(w)
 
-	go realtimeUpdate(w)
 	go pending(w)
 
 	return nil
@@ -112,7 +113,7 @@ func realtimeUpdate(w *DOM.Window) {
 func acceptPending(w *DOM.Window, tx Block.Transaction) {
 	hash := tx.Hash()
 
-	if waitVotesConfirmation(tx, 6 * time.Minute) {
+	if waitVotesConfirmation(tx, 6*time.Minute) {
 		amount, err := Node.GetAmount(Connection, tx)
 		if err != nil {
 			return

--- a/GUI/App/Background/transaction.go
+++ b/GUI/App/Background/transaction.go
@@ -128,8 +128,7 @@ func waitVotesConfirmation(tx Block.Transaction, duration time.Duration) bool {
 	start := time.Now()
 	hash := tx.Hash()
 
-	ticker := time.NewTicker(1 * time.Second)
-	for range ticker.C {
+	for range time.Tick(2 * time.Second) {
 		if Storage.TransactionStorage.IsConfirmed(&hash, &Storage.Configuration.Account.Quorum) {
 			return true
 		}
@@ -141,6 +140,5 @@ func waitVotesConfirmation(tx Block.Transaction, duration time.Duration) bool {
 		}
 	}
 
-	ticker.Stop()
 	return false
 }

--- a/Node/nano.go
+++ b/Node/nano.go
@@ -249,6 +249,10 @@ func (srv *Server) listenUDP() {
 					}
 				} else {
 					switch h.MessageType {
+					case Packets.Publish:
+						srv.PublishHandler(srv, dest, h, b)
+					case Packets.ConfirmACK:
+						srv.ConfirmACKHandler(srv, dest, h, b)
 					case Packets.NodeHandshake:
 						srv.HandshakeHandler(srv, dest, h, b)
 					}


### PR DESCRIPTION
Before the Nanollet only accept votes if the node is `isKnow()`, which has previously done the handshake.